### PR TITLE
Fix typo

### DIFF
--- a/02 - Global Pose Estimate Fusion (Example Implementation).md
+++ b/02 - Global Pose Estimate Fusion (Example Implementation).md
@@ -1052,7 +1052,7 @@ If you read the previous part of the tutorial, this should be pretty self explan
 
 But specifically for us with the use of the beacons, just adjust the pose_covariance parameter accordingly, and remember to roslaunch the adapter so the parameters will be loaded in! (Remember, lower covariance means higher confidence!)
 
-I put in some starter values for the pose covariance based off of the Marvelmind beacon reported +-2cm resolution. Since it's a covariance, it means that the diagonals are actually the variances! Which is the standard deviation squared. So... 0.02 ^ 2 = 0.004
+I put in some starter values for the pose covariance based off of the Marvelmind beacon reported +-2cm resolution. Since it's a covariance, it means that the diagonals are actually the variances! Which is the standard deviation squared. So... 0.02 ^ 2 = 0.0004
 
 ```yaml
 # roll, pitch, yaw


### PR DESCRIPTION
Apart from that little typo It's a little confusing how do you set the covariance matrix diagonal. I suppose the 0.02 number comes from the fact that the standard unit of measure for length is meter so 2cm = 0.02m. But then you assign the same variance to roll, pitch, yaw that are measured in radian. Could you clarify this point? Thanks. 